### PR TITLE
Fix JNI AttachCurrentThread for newer jni.h versions

### DIFF
--- a/cpp/include/ktbind/ktbind.hpp
+++ b/cpp/include/ktbind/ktbind.hpp
@@ -450,7 +450,7 @@ namespace java {
                     case JNI_OK:
                         break;
                     case JNI_EDETACHED:
-                        if (_vm->AttachCurrentThread(reinterpret_cast<void**>(&_env), nullptr) == JNI_OK) {
+                        if (_vm->AttachCurrentThread(&_env, nullptr) == JNI_OK) {
                             assert(_env != nullptr);
                             _attached = true;
                         } else {


### PR DESCRIPTION
I am currently trying to use your very interesting library with the Android NDK 26, and stumbled upon an issue with a breaking API change in the `jni.h` header. Namely, the AttachCurrentThread function now accepts `JNIEnv**` instead of `void**`.

I have no idea how all these JNI versions work, maybe there also needs to be an if-def as in https://github.com/leeowenowen/jni-examples/blob/070e83a5675274dc8ee86b99720723d12249cf61/invocation-interface/attach.c#L19C1-L19C1 if this is supposed to work with older versions as well.

Anyway, with the change in this PR your library now compiles again.